### PR TITLE
Parallel model tokenizer index load

### DIFF
--- a/benchmarks/bench_regex_fsm.py
+++ b/benchmarks/bench_regex_fsm.py
@@ -1,0 +1,56 @@
+import random
+
+from outlines.caching import cache_disabled
+from outlines.fsm.regex import reduced_vocabulary
+from outlines.models.tokenizer import Tokenizer
+
+from .common import ensure_numba_compiled
+
+
+class MockTokenizer(Tokenizer):
+    def __init__(self, token_strs):
+        self.eos_token = "<eos>"
+        self.eos_token_id = 0
+        self.pad_token_id = 1
+        self.special_tokens = {0, 1}
+
+        self.vocabulary = {"<eos>": 0, "<pad>": 1}
+
+        for i, tok in enumerate(token_strs):
+            self.vocabulary[tok] = i + 2
+
+    @classmethod
+    def from_random_tokens(cls, n_tokens, max_token_length=8, seed=42):
+        random.seed(seed)
+        tokens = [
+            "".join(
+                chr(random.randint(0, 4096))
+                for __ in range(random.randint(0, max_token_length))
+            )
+            for _ in range(n_tokens)
+        ]
+        return cls(tokens)
+
+    def convert_token_to_string(self, token):
+        return token
+
+    def __hash__(self):
+        return hash(tuple(sorted(self.vocabulary.items())))
+
+
+def reduced_vocabulary_uncached(*args, **kwargs):
+    return reduced_vocabulary.__wrapped__(*args, **kwargs)
+
+
+class RegexReducedVocabularyBenchmark:
+    params = [10000, 100000, 1000000]
+    param_names = ["vocab_size"]
+
+    def setup(self, vocab_size):
+        ensure_numba_compiled(MockTokenizer([chr(i) for i in range(128)]))
+
+        self.tokenizer = MockTokenizer.from_random_tokens(vocab_size)
+
+    @cache_disabled()
+    def time_reduced_vocabulary(self, _):
+        reduced_vocabulary_uncached(self.tokenizer)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,7 +138,7 @@ nav:
           - TGI: reference/models/tgi.md
           - ExllamaV2: reference/models/exllamav2.md
           - MLX: reference/models/mlxlm.md
-          - Mamba: reference/models/mamba.md
+          - Mamba: reference/models/transformers.md
         - API:
             - OpenAI: reference/models/openai.md
   - API Reference:

--- a/outlines/caching.py
+++ b/outlines/caching.py
@@ -153,8 +153,8 @@ def disable_cache():
 
     `outlines.cache.disable` should be called right after importing outlines:
 
-    >>> import outlines.cache as cache
-    >>> cache.disable()
+    >>> import outlines.caching as cache
+    >>> cache.disable_cache()
 
     """
     global _caching_enabled

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -69,7 +69,7 @@ class TransformerTokenizer(Tokenizer):
         self.eos_token_id = self.tokenizer.eos_token_id
         self.eos_token = self.tokenizer.eos_token
 
-        if not self.tokenizer.pad_token_id:
+        if self.tokenizer.pad_token_id is None:
             self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
             self.pad_token_id = self.eos_token_id
         else:


### PR DESCRIPTION
# Original Issue

The suggestion to execute reduced_vocabulary and model loading in parallel presents challenges:
- For `models.llamacpp`, the model must be loaded before accessing the tokenizer, preventing any benefits.
- Implementing this for `models.transformers_vision` would require complex changes.
- Each model loader needs a distinct implementation.

So I looked at `reduced_vocabulary` and saw a performance issue similar to one I've seen previously. I applied a similar fix from before (described below) and it works well.

# Problem

In `main`, `reduced_vocabulary` constructs a numba List in pure-python mode. There is a serious performance issue for `numba.typed.List.append()` calls in pure-python mode. 

`reduced_vocabulary` is run once when a model is loaded and used for structured generation. It is worse now that now that models are starting to have 100,000 - 200,000 token vocabularies. 

# Solution

- In pure-python construct a dict mapping token_ids to normalized token strings.
- In `@njit`, convert the dictionary to a list of tuples, where each tuple contains (`normalized_token: unicode_type`, `token_ids: int64[:]`).

# Benchmarks

New benchmarks
```
| Change   | Before [d78041e8]    | After [c87534d7]    |   Ratio | Benchmark (Parameter)                                                                                     |
|----------|----------------------|---------------------|---------|-----------------------------------------------------------------------------------------------------------|
| -        | 2.25±0.02s           | 216±2ms             |    0.1  | bench_regex_fsm.RegexReducedVocabularyBenchmark.time_reduced_vocabulary('gpt2')                           |
| -        | 5.71±0.05s           | 560±7ms             |    0.1  | bench_regex_fsm.RegexReducedVocabularyBenchmark.time_reduced_vocabulary('llama3')                         |
```

Old benchmarks
```
Benchmarks that have improved:



| Change   | Before [d78041e8]    | After [c87534d7]    |   Ratio | Benchmark (Parameter)                                                                                     |
|----------|----------------------|---------------------|---------|-----------------------------------------------------------------------------------------------------------|
| -        | 5.11±0.03s           | 3.21±0.1s           |    0.63 | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_fsm('complex_schema')                           |
| -        | 3.63±0.06s           | 1.66±0.03s          |    0.46 | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_fsm('simple_schema')                            |
| -        | 5.62±0.03s           | 3.77±0.01s          |    0.67 | bench_numba_compile.NumbaCompileBenchmark.time_compile_numba                                              |
| -        | 2.74±0.02s           | 695±20ms            |    0.25 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('complex_phone')                                |
| -        | 6.28±0.05s           | 4.40±0.1s           |    0.7  | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('complex_span_constrained_relation_extraction') |
| -        | 2.56±0.01s           | 524±10ms            |    0.2  | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('date')                                         |
| -        | 2.49±0.03s           | 487±6ms             |    0.2  | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('email')                                        |
| -        | 2.45±0.01s           | 434±10ms            |    0.18 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('ip')                                           |
| -        | 2.45±0.01s           | 397±5ms             |    0.16 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('simple_phone')                                 |
| -        | 2.39±0.04s           | 357±4ms             |    0.15 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('ssn')                                          |
| -        | 2.40±0.02s           | 348±7ms             |    0.15 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('time')                                         |
| -        | 2.61±0.01s           | 573±10ms            |    0.22 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('url')                                          |

Benchmarks that have stayed the same:
...
```