### PR TITLE
Logits processors: Update inplace, with batching

### DIFF
--- a/outlines/processors/base_logits_processor.py
+++ b/outlines/processors/base_logits_processor.py
@@ -75,10 +75,10 @@ class OutlinesLogitsProcessor(Protocol):
 
         # Guarantee passed as 2D Tensors, then covert back to original (1D or 2D) shape
         if len(torch_logits.shape) == 2:
-            processed_logits = self.process_logits(input_ids.tolist(), torch_logits)
+            processed_logits = self.process_logits(input_ids, torch_logits)
         elif len(torch_logits.shape) == 1:
             processed_logits = self.process_logits(
-                [input_ids.tolist()], torch_logits.unsqueeze(0)
+                input_ids.unsqueeze(0), torch_logits.unsqueeze(0)
             ).squeeze(0)
 
         # return logits as passed array type

--- a/outlines/processors/structured.py
+++ b/outlines/processors/structured.py
@@ -102,12 +102,13 @@ class GuideLogitsProcessor(OutlinesLogitsProcessor):
 
             sequence_states.append(self._guide_states[curr_state_key])
 
-        mask = torch.full_like(logits, -math.inf)
+        mask = torch.ones_like(logits, dtype=torch.bool)
         for i, guide_state in enumerate(sequence_states):
             allowed_tokens = self.guide.get_next_instruction(guide_state).tokens
-            mask[i, allowed_tokens] = logits[i, allowed_tokens]
+            mask[i, allowed_tokens] = False
+        logits.masked_fill_(mask, float("-inf"))
 
-        return mask
+        return logits
 
     def copy(self) -> "GuideLogitsProcessor":
         """Return a copy of the logits processor."""

--- a/outlines/processors/structured.py
+++ b/outlines/processors/structured.py
@@ -70,7 +70,7 @@ class GuideLogitsProcessor(OutlinesLogitsProcessor):
         self._seq_start_idx = None
 
     def process_logits(
-        self, input_ids: List[List[int]], logits: torch.Tensor
+        self, input_ids: torch.LongTensor, logits: torch.FloatTensor
     ) -> torch.Tensor:
         """Use the Guide to bias the logits before sampling the next token.
 
@@ -93,19 +93,32 @@ class GuideLogitsProcessor(OutlinesLogitsProcessor):
 
         for seq_ids in input_ids:
             gen_ids = seq_ids[self._seq_start_idx :]
-            curr_state_key = hash(tuple(gen_ids))
+            curr_state_key = hash(tuple(gen_ids.tolist()))
 
             if curr_state_key not in self._guide_states:
-                prev_state = self._guide_states[hash(tuple(gen_ids[:-1]))]
-                curr_state = self.guide.get_next_state(prev_state, gen_ids[-1])
+                prev_state = self._guide_states[hash(tuple(gen_ids[:-1].tolist()))]
+                curr_state = self.guide.get_next_state(prev_state, gen_ids[-1].item())
                 self._guide_states[curr_state_key] = curr_state
 
             sequence_states.append(self._guide_states[curr_state_key])
 
         mask = torch.ones_like(logits, dtype=torch.bool)
+
+        allowed_tokens_batch = []
+        batch_indices = []
         for i, guide_state in enumerate(sequence_states):
-            allowed_tokens = self.guide.get_next_instruction(guide_state).tokens
-            mask[i, allowed_tokens] = False
+            allowed_tokens = self.guide.get_next_instruction(guide_state).tokens.to(
+                mask.device, non_blocking=True
+            )
+            allowed_tokens_batch.append(allowed_tokens)
+            batch_indices.append(
+                torch.full_like(allowed_tokens, i)
+            )  # Store batch index for each allowed token
+
+        allowed_tokens_concat = torch.cat(allowed_tokens_batch)
+        batch_indices_concat = torch.cat(batch_indices)
+
+        mask[batch_indices_concat, allowed_tokens_concat] = False
         logits.masked_fill_(mask, float("-inf"))
 
         return logits
@@ -202,7 +215,7 @@ class CFGLogitsProcessor(GuideLogitsProcessor):
         super().__init__(tokenizer=tokenizer, guide=cfg_guide)
 
     def process_logits(
-        self, input_ids: List[List[int]], logits: torch.Tensor
+        self, input_ids: torch.LongTensor, logits: torch.Tensor
     ) -> torch.Tensor:
         """Same behavior as GuideLogitsProcessor, but uses rejection sampling"""
         if self._seq_start_idx is None:
@@ -212,11 +225,11 @@ class CFGLogitsProcessor(GuideLogitsProcessor):
 
         for seq_ids in input_ids:
             gen_ids = seq_ids[self._seq_start_idx :]
-            curr_state_key = hash(tuple(gen_ids))
+            curr_state_key = hash(tuple(gen_ids.tolist()))
 
             if curr_state_key not in self._guide_states:
-                prev_state = self._guide_states[hash(tuple(gen_ids[:-1]))]
-                curr_state = self.guide.get_next_state(prev_state, gen_ids[-1])
+                prev_state = self._guide_states[hash(tuple(gen_ids[:-1].tolist()))]
+                curr_state = self.guide.get_next_state(prev_state, gen_ids[-1].item())
                 self._guide_states[curr_state_key] = curr_state
 
             sequence_states.append(self._guide_states[curr_state_key])


### PR DESCRIPTION
# Changes

For `GuideLogitsProcessor`,
- Update `logits` inplace: https://github.com/lapp0/outlines/pull/92/commits/7514aff249fa089606d804d544dc1adfc1fff00d
  - Fixes https://github.com/dottxt-ai/outlines/issues/859
- Batch update logits: https://github.com/lapp0/outlines/pull/92/commits/8aa0b0dd2d33ec2b792c54fc356f4ecd7dee4b36
  - (Because I noticed GPU profile was worse than CPU due to cuda synchronization)

# Benchmarks for both changes

CI doesn't benchmark `torch_cuda`, so I've included it here.

### Update `logits` inplace

| Before [245c7fcf] | After [7514aff2] | Ratio | Benchmark (Parameter)                               |
|----------------------------|------------------|-------|-----------------------------------------------------|
| 159_0.4μs                  | 181_1μs          | 1.14  | `time_structured_generation('numpy', 'Z*')`         |
| 149_0.3μs                  | 170_0.7μs        | 1.14  | `time_structured_generation('torch', 'Z*')`         |
| 292_0.8μs                  | 254_1μs          | 0.87  | `time_structured_generation('torch_cuda', 'Z*')`    |
| 572_2μs                    | 391_1μs          | 0.68  | `time_structured_generation('torch_cuda', '[^Z]*')` |


### Batch update logits

| Before [245c7fcf] | After [8aa0b0dd] | Ratio | Benchmark (Parameter)                               |
|----------------------------|------------------|-------|-----------------------------------------------------|
| 481_5μs                    | 401_2μs          | 0.83  | `time_structured_generation('numpy', '[^Z]*')`      |
| 466_3μs                    | **386_1μs**          | 0.83  | `time_structured_generation('torch', '[^Z]*')`      |
| 159_0.8μs                  | 106_0.5μs        | 0.67  | `time_structured_generation('numpy', 'Z*')`         |
| 149_0.7μs                  | **94.7_0.2μs**       | 0.64  | `time_structured_generation('torch', 'Z*')`         |
| 290_1μs                    | **149_0.4μs**        | 0.51  | `time_structured_generation('torch_cuda', 'Z*')`    |
| 573_3μs                    | **229_1μs**          | 0.4   | `time_structured_generation('torch_cuda', '[^Z]*')` |

# Testing
- All tests pass, including `test_generate.py` with CUDA models
- Did not test on Metal.

# Further Work
- We can cache the `RegexGuide` legal token mask on GPU to improve `time_structured_generation('torch', '[^Z]*')`. In this benchmark, `allowed_tokens` is all tokens except `Z`, `ZZ`, and `ZZZ`, resulting in a large `LongTensor` being sent to GPU each step.